### PR TITLE
ci: run pip smoke-test from /tmp to avoid source shadowing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
         run: pip install --no-build-isolation .
       - name: Import smoke-test
         run: python -c "from jaxtra.scipy.linalg import qr_multiply; print('ok')"
+        working-directory: /tmp
 
   # ── Sphinx docs build (conf.py stubs the C extension — no .so needed) ────
   docs:


### PR DESCRIPTION
Python adds CWD to sys.path; running from the checkout means jaxtra/ in the source tree shadows the installed package in site-packages, so _load_so never finds _jaxtra.so.

https://claude.ai/code/session_01DngAcJCtbsirwp5BapyH84